### PR TITLE
adds automation for cutting builder releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,6 +36,7 @@ jobs:
         pack build testapp -p samples/nodejs/yarn --builder testbuilder
         pack build testapp -p samples/go/mod --builder testbuilder
         pack build testapp -p samples/java/maven --builder testbuilder
+        pack build testapp -p samples/ruby/puma --builder testbuilder
 
   release:
     name: Release

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,72 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  smoke:
+    name: Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+
+    # Use :latest image when we have confidence in latest releases
+    # Current latest (0.14.0) has a runtime error
+    - name: Install Pack
+      run: |
+        id=$(docker create buildpacksio/pack:0.14.0)
+        sudo docker cp $id:/layers/paketo-buildpacks_go-build/targets/bin/pack /usr/local/bin/
+        docker rm -v $id
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: builder-repo
+
+    - name: Checkout paketo samples
+      uses: actions/checkout@v2
+      with:
+        repository: paketo-buildpacks/samples
+        path: samples
+
+    - name: Run smoke tests
+      run: |
+        pack create-builder testbuilder --config builder-repo/builder.toml
+        pack build testapp -p samples/nodejs/yarn --builder testbuilder
+        pack build testapp -p samples/go/mod --builder testbuilder
+        pack build testapp -p samples/java/maven --builder testbuilder
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: smoke
+    steps:
+    - name: Checkout With History
+      uses: actions/checkout/@v2
+      with:
+        fetch-depth: 0 # gets full history
+    - name: Compare With Previous Release
+      id: compare_previous_release
+      run: |
+        if [ -z "$(git diff $(git describe --tags --abbrev=0) -- builder.toml)" ]
+        then
+          echo "::set-output name=builder_changes::false"
+        else
+          echo "::set-output name=builder_changes::true"
+        fi
+    - name: Tag
+      id: tag
+      if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
+      uses: paketo-buildpacks/github-config/actions/tag@main
+    - name: Create Release
+      if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
+      uses: paketo-buildpacks/github-config/actions/release/create@main
+      with:
+        repo: ${{ github.repository }}
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        tag_name: v${{ steps.tag.outputs.tag }}
+        target_commitish: ${{ github.sha }}
+        name: v${{ steps.tag.outputs.tag }}
+        body: "See builder.toml file"
+        draft: false


### PR DESCRIPTION
**Don't merge until initial `builder.toml` is merged in #6 and the first release 0.1.0 is cut manually.**
Resolves #1
Signed-off-by: Sophie Wigmore <swigmore@vmware.com>